### PR TITLE
fix: remove redundant entry basic block

### DIFF
--- a/include/mctomir/mctomir-transform.h
+++ b/include/mctomir/mctomir-transform.h
@@ -87,7 +87,6 @@ private:
   std::unique_ptr<Module> mod;
   Function *func;
   MachineFunction *mfunc;
-  MachineBasicBlock *initial_mbb;
 
   std::vector<translated_inst> instructions;
   std::vector<block_info> blocks;
@@ -102,7 +101,6 @@ private:
   Error create_machine_basic_blocks();
   Error translate_instructions();
   Error link_machine_basic_blocks();
-  Error create_initial_basic_block();
 
   MachineInstr *convert_to_machine_instr(const MCInst &inst, uint64_t address);
   MachineOperand convert_operand(const MCOperand &op, const MCInst &inst);

--- a/lib/mctomir/mctomir-transform.cpp
+++ b/lib/mctomir/mctomir-transform.cpp
@@ -164,8 +164,6 @@ Error translator_t::finalize() {
                              "No instructions to translate");
 
   // TODO(Ilyagavrilin): Rewrite this chain
-  if (Error err = create_initial_basic_block())
-    return err;
   if (Error err = identify_basic_blocks())
     return err;
   if (Error err = create_machine_basic_blocks())
@@ -175,18 +173,6 @@ Error translator_t::finalize() {
   if (Error err = link_machine_basic_blocks())
     return err;
 
-  return Error::success();
-}
-
-Error translator_t::create_initial_basic_block() {
-  MachineBasicBlock *entry_mbb = mfunc->CreateMachineBasicBlock();
-  mfunc->push_back(entry_mbb);
-  // TODO(Ilyagavrilin): check cases when we really need to sort
-  llvm::stable_sort(instructions, [](auto &lhs, auto &rhs) {
-    return lhs.address < rhs.address;
-  });
-
-  initial_mbb = entry_mbb;
   return Error::success();
 }
 
@@ -420,7 +406,7 @@ target &translator_t::get_or_create_target() {
 void translator_t::make_returns() {
   assert(mfunc);
   auto &tgt = get_or_create_target();
-  for (auto &mblock : drop_begin(*mfunc)) {
+  for (auto &mblock : *mfunc) {
     auto &last = mblock.back();
     if (last.isReturn())
       continue;

--- a/test/tools/mctomir/foo.c
+++ b/test/tools/mctomir/foo.c
@@ -4,6 +4,8 @@
 int foo() { return 42; }
 
 // CHECK: name: disassembled_function
+// CHECK: body:
+// CHECK-NEXT: bb.0:
 // CHECK: $x10 = ADDI $x0, 42
 // CHECK: PseudoRET
 // CHECK-SAME: $x1


### PR DESCRIPTION
This commit removes the redundant (first) block in the lifted function